### PR TITLE
Recode of the main command class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hhitt.org.example</groupId>
     <artifactId>FancyGlow</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>FancyGlow</name>
@@ -66,7 +66,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <outputDirectory>./jars</outputDirectory>
+                    <outputDirectory>D:\TestingServer\1_20_4\plugins</outputDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <outputDirectory>D:\TestingServer\1_20_4\plugins</outputDirectory>
+                    <outputDirectory>./jars</outputDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/hhitt/fancyglow/commands/SubcommandTabSuggestion.java
+++ b/src/main/java/hhitt/fancyglow/commands/SubcommandTabSuggestion.java
@@ -32,6 +32,9 @@ public class SubcommandTabSuggestion implements TabCompleter {
 
         boolean hasAdminPermission = sender.hasPermission("fancyglow.admin");
         boolean canDisable = sender.hasPermission("fancyglow.command.disable");
+        boolean canDisableOthers = sender.hasPermission("fancyglow.command.disable.others");
+        boolean canDisableEveryone = sender.hasPermission("fancyglow.command.disable.everyone");
+        boolean canReload = sender.hasPermission("fancyglow.command.reload");
         boolean canColor = sender.hasPermission("fancyglow.command.color");
 
         //Suggest for disable and color
@@ -41,6 +44,7 @@ public class SubcommandTabSuggestion implements TabCompleter {
                 completions.addAll(Arrays.asList("disable", "reload", "color"));
             } else {
                 if (canDisable) completions.add("disable");
+                if (canReload) completions.add("reload");
                 if (canColor) completions.add("color");
             }
 
@@ -69,14 +73,16 @@ public class SubcommandTabSuggestion implements TabCompleter {
                 return filter(completions, args[1]);
             }
 
-            if (args[0].equalsIgnoreCase("disable") && (canDisable && hasAdminPermission)) {
+            if (args[0].equalsIgnoreCase("disable") && (canDisableOthers || hasAdminPermission)) {
 
                 completions = Bukkit.getOnlinePlayers()
                         .stream()
                         .map(Player::getName)
                         .collect(Collectors.toList());
 
-                completions.add("all");
+                if (canDisableEveryone) {
+                    completions.add("all");
+                }
 
                 return completions;
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,7 @@ Messages:
   Reload_Message: "<blue>Plugin configuration file reloaded successfully!"
   Enable_Glow: "<green>Now you are glowing!"
   Disable_Glow: "<red>You aren't glowing anymore!"
+  Disable_Usage: "<red>Correct usage is: /glow disable <player>"
   Disable_Glow_Others: "<red>You have disabled glow of %player_name%"
   Disable_Glow_Everyone: "<red>You have disabled glow to everyone online."
   Not_Glowing: "<red>You are not glowing!"
@@ -32,6 +33,7 @@ Messages:
   Wrong_Usage_Color_Command: "<red>Wrong command usage! Use like: <gold>/glow color <color></gold>."
   Unknown_Target: "<red>Player %player_name% is not online!"
   Target_Not_Glowing: "<red>Target is not glowing!"
+  Invalid_Sub_Command: "<red>Unknown sub-command \"%sub_command%\"."
 
 
   # Message that player gets when enter on a disabled world

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,7 @@
 
 # Useful links:
 # Documentation: https://hhitt-1.gitbook.io/fancy-glow-documentation
-# Discord for support, suggestions & more: https://discord.com/invite/W7R3mPXzQ7
+# Discord for support, suggestions & more: https://discord.com/invite/6SgzfJFVwq
 # MiniMessage tool that make it faster ;) https://webui.advntr.dev/
 
 #While a player leave the server should the glow mode persist?

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: FancyGlow
 author: hhitt
-version: 2.2.1
+version: '${project.version}'
 main: hhitt.fancyglow.FancyGlow
 api-version: '1.20'
 softdepend: [ PlaceholderAPI ]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,3 +10,16 @@ commands:
     usage: /<command>
     aliases:
       - fancyglow
+
+permissions:
+  fancyglow.admin:
+    description: Gives permission to every fancy glow command and feature.
+    children:
+      fancyglow.rainbow: true
+      fancyglow.all_colors: true
+      fancyglow.command.gui: true
+      fancyglow.command.color: true
+      fancyglow.command.reload: true
+      fancyglow.command.disable: true
+      fancyglow.command.disable.everyone: true
+      fancyglow.command.disable.others: true


### PR DESCRIPTION
This version (2.3.0) has received a recode of the main command class.

Fixes:
Problems with messages and colors in console.
Problems with the use of sub-commands in console.
Logic in the use of commands.
Now gives sub-command suggestions if you have the permissions.


Others:
Automatically update plugin version when updating from pom.xml.
Updated the discord invite link.
Added inheritance of all commands/functions to fancyglow.admin permission.

**!!** This version needs 2 new messages
`Invalid_Sub_Command: “<red>Unknown sub-command \”%sub_command%\”.”`
`Disable_Usage: “<red>Correct usage is: /glow disable <player>”`