### PR TITLE
Small changes and improvements

### DIFF
--- a/src/main/java/hhitt/fancyglow/commands/MainCommand.java
+++ b/src/main/java/hhitt/fancyglow/commands/MainCommand.java
@@ -12,6 +12,7 @@ import hhitt.fancyglow.utils.Messages;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import revxrsal.commands.annotation.Command;
 import revxrsal.commands.annotation.Description;
@@ -150,12 +151,12 @@ public class MainCommand {
         }
 
         // Handles normal colors.
-        if (ColorUtils.findColor(colorName.toUpperCase()) == null) {
+        ChatColor color = ColorUtils.findColor(colorName.toUpperCase());
+        if (color == null) {
             messageHandler.sendMessage(player, Messages.INVALID_COLOR);
             return;
         }
 
-        ChatColor color = ColorUtils.findColor(colorName.toUpperCase());
         if (!(glowManager.hasGlowPermission(player, color) || player.hasPermission("fancyglow.all_colors"))) {
             messageHandler.sendMessage(player, Messages.NO_PERMISSION);
             return;
@@ -188,7 +189,7 @@ public class MainCommand {
         }
 
         Player target = Bukkit.getPlayer(targetName);
-        if (Bukkit.getPlayer(targetName) == null) {
+        if (target == null) {
             messageHandler.sendMessageBuilder(sender, Messages.UNKNOWN_TARGET)
                     .placeholder("%player_name%", targetName)
                     .send();
@@ -225,12 +226,12 @@ public class MainCommand {
         }
 
         // Handles normal colors.
-        if (ColorUtils.findColor(colorName.toUpperCase()) == null) {
+        ChatColor color = ColorUtils.findColor(colorName.toUpperCase());
+        if (color == null) {
             messageHandler.sendMessage(sender, Messages.INVALID_COLOR);
             return;
         }
 
-        ChatColor color = ColorUtils.findColor(colorName.toUpperCase());
         glowManager.setGlow(target, color);
         if (!silent) {
             messageHandler.sendMessage(target, Messages.ENABLE_GLOW);
@@ -242,13 +243,12 @@ public class MainCommand {
     @Command({"glow disable", "fancyglow disable"})
     @Description("Allow player to disable its own glow and others if it has permissions to.")
     public void disableCommand(BukkitCommandActor actor, @Optional String targetName) {
-        if (actor.isConsole() && targetName == null) {
-            messageHandler.sendMessage(actor.sender(), Messages.DISABLE_COMMAND_USAGE);
+        final CommandSender sender = actor.sender();
+        if (!(sender instanceof ConsoleCommandSender) && targetName == null) {
+            messageHandler.sendMessage(sender, Messages.DISABLE_COMMAND_USAGE);
             return;
         }
-
-        if (actor.isPlayer() && targetName == null) {
-            Player player = actor.asPlayer();
+        if (sender instanceof Player player && targetName == null) {
             // Check if the player has permission to disable their own glow
             if (!player.hasPermission("fancyglow.command.disable")) {
                 messageHandler.sendMessage(player, Messages.NO_PERMISSION);
@@ -266,11 +266,11 @@ public class MainCommand {
         }
 
         if (targetName.equalsIgnoreCase("all")) {
-            handleDisableAll(actor.sender());
+            handleDisableAll(sender);
             return;
         }
 
-        disableOtherGlow(actor.sender(), targetName);
+        disableOtherGlow(sender, targetName);
     }
 
     private void disableOtherGlow(CommandSender sender, String targetName) {

--- a/src/main/java/hhitt/fancyglow/commands/lamp/ColorSuggestionFactory.java
+++ b/src/main/java/hhitt/fancyglow/commands/lamp/ColorSuggestionFactory.java
@@ -35,7 +35,7 @@ public final class ColorSuggestionFactory implements SuggestionProvider.Factory<
         // Just reuse available-colors set instead of create a new one.
         Set<String> availableColors = ColorUtils.getAvailableColorsSet();
         return context -> {
-            // Basically, we reduce a bit the object-alloc and we avoid us an extra method-call for a
+            // Basically, we reduce a bit the object-alloc and we avoid us an extra calls for a
             // simple [instanceof] check.
             if (!(context.actor().sender() instanceof Player player)) return availableColors;
 

--- a/src/main/java/hhitt/fancyglow/commands/lamp/ColorSuggestionFactory.java
+++ b/src/main/java/hhitt/fancyglow/commands/lamp/ColorSuggestionFactory.java
@@ -12,9 +12,7 @@ import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 public final class ColorSuggestionFactory implements SuggestionProvider.Factory<BukkitCommandActor> {
@@ -34,14 +32,14 @@ public final class ColorSuggestionFactory implements SuggestionProvider.Factory<
         // Verify if annotation is present.
         if (annotations.get(ColorSuggestion.class) == null) return null;
 
-        Set<String> availableColors = new HashSet<>(ColorUtils.getAvailableColorsSet());
-
+        // Just reuse available-colors set instead of create a new one.
+        Set<String> availableColors = ColorUtils.getAvailableColorsSet();
         return context -> {
-            BukkitCommandActor actor = context.actor();
-            if (actor.isConsole()) return availableColors;
+            // Basically, we reduce a bit the object-alloc and we avoid us an extra method-call for a
+            // simple [instanceof] check.
+            if (!(context.actor().sender() instanceof Player player)) return availableColors;
 
-            Player player = Objects.requireNonNull(actor.asPlayer());
-            List<String> list = new ArrayList<>();
+            List<String> list = new ArrayList<>(availableColors.size());
             for (String name : availableColors) {
                 if (glowManager.hasGlowPermission(player, name)) {
                     list.add(name);

--- a/src/main/java/hhitt/fancyglow/inventory/CreatingInventory.java
+++ b/src/main/java/hhitt/fancyglow/inventory/CreatingInventory.java
@@ -50,13 +50,14 @@ public class CreatingInventory implements InventoryHolder {
         int i = 9;
         ItemStack colorItem;
         LeatherArmorMeta colorMeta;
+        // Preferably we'll want to avoid us the object-alloc that involves the #getMessages method.
+        List<String> colorLoreMessage = messageHandler.getMessages(Messages.COLOR_LORE);
         for (ChatColor availableColor : GlowManager.COLORS_ARRAY) {
             colorItem = new ItemStack(Material.LEATHER_CHESTPLATE);
             colorMeta = (LeatherArmorMeta) colorItem.getItemMeta();
 
-            colorMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-            colorMeta.addItemFlags(ItemFlag.HIDE_DYE);
-            colorMeta.setLore(messageHandler.getMessages(Messages.COLOR_LORE));
+            colorMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE);
+            colorMeta.setLore(colorLoreMessage);
             // Might cause IllegalArgumentException if message doesn't exist.
             Messages colorMessage = Messages.valueOf(availableColor.name().toUpperCase() + "_NAME");
             colorMeta.setDisplayName(messageHandler.getMessage(colorMessage));
@@ -91,7 +92,6 @@ public class CreatingInventory implements InventoryHolder {
         fillMeta.setDisplayName(messageHandler.getMessage(Messages.FILLER_NAME));
         fill.setItemMeta(fillMeta);
 
-        // Avoid call to getSize() on every iteration.
         for (int i = 0; i < inventory.getSize(); i++) {
             inventory.setItem(i, fill);
         }
@@ -140,8 +140,10 @@ public class CreatingInventory implements InventoryHolder {
             meta.setLore(messageHandler.getMessages(Messages.HEAD_LORE_CLICK));
         } else {
             List<String> parsedMessage = new ArrayList<>();
-            List<String> list = messageHandler.sendMessageBuilder(player, Messages.HEAD_LORE_SELECTED).placeholder("%mode%", mode).parseList();
-            list.forEach(line -> parsedMessage.add(MessageUtils.miniMessageParse(line)));
+            messageHandler.sendMessageBuilder(player, Messages.HEAD_LORE_SELECTED)
+                    .placeholder("%mode%", mode)
+                    .parseList()
+                    .forEach(line -> parsedMessage.add(MessageUtils.miniMessageParse(line)));
             meta.setLore(parsedMessage);
         }
 

--- a/src/main/java/hhitt/fancyglow/listeners/HeadClickListener.java
+++ b/src/main/java/hhitt/fancyglow/listeners/HeadClickListener.java
@@ -34,12 +34,12 @@ public class HeadClickListener implements Listener {
         if (currentItem == null || currentItem.getType() != Material.PLAYER_HEAD) return;
 
         Player player = (Player) event.getWhoClicked();
+        player.closeInventory();
         switch (event.getSlot()) {
             // Multicolor head
             case 39 -> {
                 if (!player.hasPermission("fancyglow.rainbow")) {
                     messageHandler.sendMessage(player, Messages.NO_PERMISSION);
-                    player.closeInventory();
                     return;
                 }
 
@@ -50,7 +50,6 @@ public class HeadClickListener implements Listener {
                 }
 
                 // Toggle rainbow mode
-                player.closeInventory();
                 boolean toggled = glowManager.toggleMulticolorGlow(player);
                 messageHandler.sendMessage(player, toggled ? Messages.ENABLE_RAINBOW : Messages.DISABLE_RAINBOW);
             }
@@ -58,7 +57,6 @@ public class HeadClickListener implements Listener {
             case 40 -> {
                 if (!player.hasPermission("fancyglow.flashing")) {
                     messageHandler.sendMessage(player, Messages.NO_PERMISSION);
-                    player.closeInventory();
                     return;
                 }
 
@@ -71,11 +69,9 @@ public class HeadClickListener implements Listener {
                 // Toggle flashing mode
                 boolean toggled = glowManager.toggleFlashingGlow(player);
                 messageHandler.sendMessage(player, toggled ? Messages.ENABLE_FLASHING : Messages.DISABLE_GLOW);
-                player.closeInventory();
             }
             // Disable color head
             case 41 -> {
-                player.closeInventory();
                 glowManager.removeGlow(player);
                 messageHandler.sendMessage(player, Messages.DISABLE_GLOW);
             }

--- a/src/main/java/hhitt/fancyglow/listeners/MenuClickListener.java
+++ b/src/main/java/hhitt/fancyglow/listeners/MenuClickListener.java
@@ -38,26 +38,23 @@ public class MenuClickListener implements Listener {
         ItemStack clickedItem = e.getCurrentItem();
         if (clickedItem == null || clickedItem.getType() != Material.LEATHER_CHESTPLATE) return;
 
-        LeatherArmorMeta meta = (LeatherArmorMeta) clickedItem.getItemMeta();
-        if (meta == null) return;
-
-        ChatColor color = ColorUtils.getColorFromArmorColor(meta.getColor());
+        // The clicked-item already is of leather-type, why should we check if also it has an item-meta?
+        // It won´t be null.
+        ChatColor color = ColorUtils.getColorFromArmorColor(((LeatherArmorMeta) clickedItem.getItemMeta()).getColor());
         if (color == null) return;
 
         Player player = (Player) e.getWhoClicked();
+        player.closeInventory();
         if (!glowManager.hasGlowPermission(player, color) || !player.hasPermission("fancyglow.all_colors")) {
             messageHandler.sendMessage(player, Messages.NO_PERMISSION);
-            player.closeInventory();
             return;
         }
 
         if (!glowManager.isMulticolorTaskActive(player) && playerGlowManager.getPlayerGlowColorName(player).equalsIgnoreCase(color.name())) {
             messageHandler.sendMessage(player, Messages.COLOR_ALREADY_SELECTED);
-            player.closeInventory();
             return;
         }
 
-        player.closeInventory();
         glowManager.setGlow(player, color);
         messageHandler.sendMessage(player, Messages.ENABLE_GLOW);
     }

--- a/src/main/java/hhitt/fancyglow/managers/GlowManager.java
+++ b/src/main/java/hhitt/fancyglow/managers/GlowManager.java
@@ -203,9 +203,9 @@ public class GlowManager {
     }
 
     public List<Team> getGlowTeams() {
-        Scoreboard board = scoreboardManager.getMainScoreboard();
-        List<Team> teamsList = new ArrayList<>(board.getTeams().size());
-        for (Team team : board.getTeams()) {
+        Set<Team> scoreboardTeams = scoreboardManager.getMainScoreboard().getTeams();
+        List<Team> teamsList = new ArrayList<>(scoreboardTeams.size());
+        for (Team team : scoreboardTeams) {
             if (ColorUtils.isAvailableColor(team.getName())) {
                 teamsList.add(team);
             }

--- a/src/main/java/hhitt/fancyglow/managers/GlowManager.java
+++ b/src/main/java/hhitt/fancyglow/managers/GlowManager.java
@@ -8,11 +8,10 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 public class GlowManager {
 
@@ -39,6 +38,7 @@ public class GlowManager {
 
     private final Set<UUID> flashingPlayerSet;
     private final Set<UUID> multicolorPlayerSet;
+    private final ScoreboardManager scoreboardManager;
 
     private BukkitTask flashingTask;
     private BukkitTask multicolorTask;
@@ -48,6 +48,9 @@ public class GlowManager {
 
         this.flashingPlayerSet = new HashSet<>();
         this.multicolorPlayerSet = new HashSet<>();
+
+        // It could be null at this point?
+        this.scoreboardManager = plugin.getServer().getScoreboardManager();
     }
 
     public boolean toggleMulticolorGlow(Player player) {
@@ -99,8 +102,7 @@ public class GlowManager {
         // Remove any existing glow
         removeGlow(player);
         // Add the player to the team and enable glowing
-        Team team = getOrCreateTeam(color);
-        team.addEntry(ChatColor.stripColor(player.getName()));
+        getOrCreateTeam(color).addEntry(ChatColor.stripColor(player.getName()));
         player.setGlowing(true);
     }
 
@@ -112,9 +114,7 @@ public class GlowManager {
     }
 
     public void removePlayerFromAllTeams(Player player) {
-        if (plugin.getServer().getScoreboardManager() == null) return;
-
-        Scoreboard board = plugin.getServer().getScoreboardManager().getMainScoreboard();
+        Scoreboard board = scoreboardManager.getMainScoreboard();
         String cleanName = ChatColor.stripColor(player.getName());
 
         // Handle remove if rainbow selected
@@ -133,19 +133,18 @@ public class GlowManager {
         Team team;
         for (final ChatColor color : COLORS_ARRAY) {
             team = board.getTeam(color.name());
-            if (team != null && team.hasEntry(cleanName)) {
+            if (team != null) {
                 team.removeEntry(cleanName);
             }
         }
     }
 
     public Team getOrCreateTeam(ChatColor color) {
-        if (plugin.getServer().getScoreboardManager() == null) return null;
-
-        Scoreboard board = plugin.getServer().getScoreboardManager().getMainScoreboard();
-        Team team = board.getTeam(color.name());
+        Scoreboard board = scoreboardManager.getMainScoreboard();
+        String colorName = color.name();
+        Team team = board.getTeam(colorName);
         if (team == null) {
-            team = board.registerNewTeam(color.name());
+            team = board.registerNewTeam(colorName);
             team.setColor(color);
         }
         return team;
@@ -203,18 +202,14 @@ public class GlowManager {
         return multicolorPlayerSet;
     }
 
-    public Set<Team> getGlowTeams() {
-        if (plugin.getServer().getScoreboardManager() == null) {
-            return Set.of();
-        }
-
-        Scoreboard board = plugin.getServer().getScoreboardManager().getMainScoreboard();
-        Set<Team> teamList = new HashSet<>();
+    public List<Team> getGlowTeams() {
+        Scoreboard board = scoreboardManager.getMainScoreboard();
+        List<Team> teamsList = new ArrayList<>(board.getTeams().size());
         for (Team team : board.getTeams()) {
             if (ColorUtils.isAvailableColor(team.getName())) {
-                teamList.add(team);
+                teamsList.add(team);
             }
         }
-        return teamList;
+        return teamsList;
     }
 }

--- a/src/main/java/hhitt/fancyglow/managers/PlayerGlowManager.java
+++ b/src/main/java/hhitt/fancyglow/managers/PlayerGlowManager.java
@@ -55,7 +55,7 @@ public class PlayerGlowManager {
      */
     public String getPlayerGlowColorName(Player player) {
         Team team = findPlayerTeam(player);
-        return (player.isGlowing() && team != null) ? team.getColor().name() : messageHandler.getMessage(Messages.GLOW_STATUS_NONE);
+        return (team != null && player.isGlowing()) ? team.getColor().name() : messageHandler.getMessage(Messages.GLOW_STATUS_NONE);
     }
 
     /**

--- a/src/main/java/hhitt/fancyglow/tasks/FlashingTask.java
+++ b/src/main/java/hhitt/fancyglow/tasks/FlashingTask.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public class FlashingTask extends BukkitRunnable {
@@ -24,8 +23,7 @@ public class FlashingTask extends BukkitRunnable {
 
         Player player;
         for (UUID uuid : glowManager.getFlashingPlayerSet()) {
-            // If the uuid is still stored, means the player is online, so the reference shouldn't be null.
-            player = Objects.requireNonNull(Bukkit.getPlayer(uuid));
+            player = Bukkit.getPlayer(uuid);
             // Ignore if player is on respawn screen.
             if (player.isDead()) continue;
 

--- a/src/main/java/hhitt/fancyglow/tasks/FlashingTask.java
+++ b/src/main/java/hhitt/fancyglow/tasks/FlashingTask.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class FlashingTask extends BukkitRunnable {
@@ -23,7 +24,7 @@ public class FlashingTask extends BukkitRunnable {
 
         Player player;
         for (UUID uuid : glowManager.getFlashingPlayerSet()) {
-            player = Bukkit.getPlayer(uuid);
+            player = Objects.requireNonNull(Bukkit.getPlayer(uuid));
             // Ignore if player is on respawn screen.
             if (player.isDead()) continue;
 

--- a/src/main/java/hhitt/fancyglow/tasks/MulticolorTask.java
+++ b/src/main/java/hhitt/fancyglow/tasks/MulticolorTask.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.Team;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class MulticolorTask extends BukkitRunnable {
@@ -32,7 +33,7 @@ public class MulticolorTask extends BukkitRunnable {
         Player player;
         Team lastTeam;
         for (UUID uuid : glowManager.getMulticolorPlayerSet()) {
-            player = Bukkit.getPlayer(uuid);
+            player = Objects.requireNonNull(Bukkit.getPlayer(uuid));
             // Ignore if player is on respawn screen.
             if (player.isDead()) continue;
 

--- a/src/main/java/hhitt/fancyglow/tasks/MulticolorTask.java
+++ b/src/main/java/hhitt/fancyglow/tasks/MulticolorTask.java
@@ -4,12 +4,10 @@ import hhitt.fancyglow.FancyGlow;
 import hhitt.fancyglow.managers.GlowManager;
 import hhitt.fancyglow.managers.PlayerGlowManager;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.Team;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public class MulticolorTask extends BukkitRunnable {
@@ -28,17 +26,13 @@ public class MulticolorTask extends BukkitRunnable {
         // Cancel task if none at this set
         if (glowManager.getMulticolorPlayerSet().isEmpty()) return;
 
-        // Get current color iteration.
-        ChatColor currentColor = GlowManager.COLORS_ARRAY[currentIndex];
-
         // Get or create the team corresponding to the current color
-        Team currentTeam = glowManager.getOrCreateTeam(currentColor);
+        Team currentTeam = glowManager.getOrCreateTeam(GlowManager.COLORS_ARRAY[currentIndex]);
 
         Player player;
         Team lastTeam;
         for (UUID uuid : glowManager.getMulticolorPlayerSet()) {
-            // If the uuid is still stored, means the player is online, so the reference shouldn't be null.
-            player = Objects.requireNonNull(Bukkit.getPlayer(uuid));
+            player = Bukkit.getPlayer(uuid);
             // Ignore if player is on respawn screen.
             if (player.isDead()) continue;
 

--- a/src/main/java/hhitt/fancyglow/utils/MessageHandler.java
+++ b/src/main/java/hhitt/fancyglow/utils/MessageHandler.java
@@ -253,16 +253,14 @@ public class MessageHandler {
         }
 
         public String parse() {
-            String rawMessage = getRawMessage(message.getPath());
-            return applyPlaceholders(rawMessage, placeholders);
+            return applyPlaceholders(getRawMessage(message.getPath()), placeholders);
         }
 
         public List<String> parseList() {
             List<String> parsedMessage = new ArrayList<>();
-            List<String> rawMessage = getRawStringList(message.getPath());
 
             if (messages.isList(message.getPath())) {
-                rawMessage.forEach(line -> parsedMessage.add(applyPlaceholders(line, placeholders)));
+                getRawStringList(message.getPath()).forEach(line -> parsedMessage.add(applyPlaceholders(line, placeholders)));
             } else {
                 parsedMessage.add(applyPlaceholders(getMessage(message), placeholders));
             }


### PR DESCRIPTION
This PR provides some improvements and changes for the code.

# Improvements
* Now `MessageUtils#getMessage(Messages.COLOR_LORE)`'s value is stored to avoid repeteadly objects creation by the method when inventory is being setting up, and removed extra `List` object in `CreatingInventory#setPlayerStatusItem`. [`b4f8263`](https://github.com/aivruu/FancyGlow/commit/b4f8263458978c580db7bb44f29dbcf82261544e)
* Now `ChatColor` reference for current-index is given directly to the `GlowManager#getOrCreateTeam` method in the class `MulticolorTask`. [`b1bc06d`](https://github.com/aivruu/FancyGlow/commit/b1bc06d64b405dbc2369e13e22b8da0f3762e838)
* Improved `ColorSuggestionFactory#create` by reuse the `ColorUtils#getAvailableColorsSet`'s `Set` instead of create a new one and reduced amount of method-calls for sender-type checking and player getting. [`31b5660`](https://github.com/aivruu/FancyGlow/commit/31b5660b054eaa948505ed4321714e20f69bd3ac)
* Improved `GlowManager` by reusing `ScoreboardManager` (removed null-checks from methods), removed call to `Team#hasEntry` for player from teams deletion, reuse `color#name` and return a `List` instead of a `Set` object and reuse `Scoreboard#getTeams` result for method `getGlowTeams`. [`09f544a`](https://github.com/aivruu/FancyGlow/commit/09f544a32eba900d6626dfb6a91cc6e451e285ef) [`ee63040`](https://github.com/aivruu/FancyGlow/commit/ee630406b268715d908c7ae0df483f78a890871f)
* Modified condition-order in `PlayerGlowManager#getPlayerGlowColorName` to check more lightweight conditions at first place. [`4978bb4`](https://github.com/aivruu/FancyGlow/commit/4978bb40e6750350d47f2ee1f8f4ef51a145510f)
* Deleted double-lookups in `MainCommand` class' methods for target-player and color-types, modified sender-type conditions and reuse `BukkitCommandActor#sender` result. [`aa7561f`](https://github.com/aivruu/FancyGlow/commit/aa7561f22bbd24d938cd5f0497e54d2c9e80ba10)

# Changes
* Removed condition in `MenuClickListener#onInventoryClick` method for leather-item's item-meta availability when clicked-item already is of that type. [`07e3022`](https://github.com/aivruu/FancyGlow/commit/07e30222ffc5b8bd9e4c7566de85938b260e28b6)
* Reduced amount of calls to `Player#closeInventory` in inventory-listeners to a single one to avoid repeated code. [`ad93595`](https://github.com/aivruu/FancyGlow/commit/ad935955a7764d2891d7edba8725b75d4daaa516) [`07e3022`](https://github.com/aivruu/FancyGlow/commit/07e30222ffc5b8bd9e4c7566de85938b260e28b6)